### PR TITLE
Include scrolling to the id specified in the lazy validation directive.

### DIFF
--- a/docs/app/views/modules.html
+++ b/docs/app/views/modules.html
@@ -251,6 +251,8 @@
             <h2>lazy-validation</h2>
               <div>
                 <p>This module enables angular validation to be triggered lazily, when a specific event occurs (such as clicking on a submit button)</p>
+                <p>When the error ocurrs because the form is invalid, if an id is provided (should be to the top where
+                  error messages are displayed) it will do the scrolling</p>
                 <p>It also uses the focus directive so when clicking in the error link it will scroll to the right input
                   and set the focus</p>
               </div>
@@ -299,6 +301,7 @@
                       <input class="btn btn-default"
                       type="submit"
                       value="Submit form"
+                      data-move-page-to="error-summary-heading-example-2"
                       data-lazy-validation-on-click="submitForm()">
                       <input class="btn btn-default"
                         type="submit"
@@ -357,6 +360,7 @@
                     <input class="btn btn-default"
                       type="submit"
                       value="Submit form (manual validation check)"
+                      data-move-page-to="error-summary-heading-example-2"
                       data-lazy-validation-on-click
                       data-ng-click="checkValidationManually()">
                   </form>

--- a/src/modules/form-validation/lazy-validation-on-click.directive.js
+++ b/src/modules/form-validation/lazy-validation-on-click.directive.js
@@ -3,18 +3,23 @@
 
   angular
       .module('ngGovUk.form-validation.lazy-validation-on-click', [
-        'ngGovUk.form-validation.lazy-validation'
+        'ngGovUk.form-validation.lazy-validation',
+        'smoothScroll'
       ])
-      .directive('lazyValidationOnClick', lazyValidationOnClick);
+      .directive('lazyValidationOnClick', ['smoothScroll', '$window', lazyValidationOnClick]);
 
   /**
-   * This directive triggers revalidation of a form on a click event
+   * @name lazyVAlidationOnClick
+   * @desc This directive triggers revalidation of a form on a click event and scrolls to the id provided if form is invalid
+   * (should go to the error message validation)
    *
+   * @example
+   * <div id="error-summary"></div>
    * <form lazy-validation="scopePropertyToBindFormValidation">
-   *     <button lazy-validation-on-click="optionalCallbackWhenFormValid()" />
+   *     <button data-move-page-to="error-summary" lazy-validation-on-click="optionalCallbackWhenFormValid()" />
    * </form>
    */
-  function lazyValidationOnClick() {
+  function lazyValidationOnClick(smoothScroll, $window) {
     return {
       restrict: 'A',
       require: '^^lazyValidation',
@@ -26,6 +31,12 @@
 
           if (lazyValidationController.isValid() && $scope.ifValidCallback) {
             $scope.ifValidCallback();
+          } else {
+            var id = attrs.movePageTo;
+            var element = $window.document.getElementById(id);
+            if(element) {
+              smoothScroll(element);
+            }
           }
         };
 


### PR DESCRIPTION
This update in the lazy-validation-on-click directive allow the user to pass the an id where to scroll in the page when the form is invalid. If the id is not passed or it is not found in the document there will not be scrolling. Changes:
- Update validation-on-click directive to include the smoothScrolling to the id provided if it is found in the document
- Update unit test to reflect changes
- Update modules to provide an example
